### PR TITLE
trait Engine: In 'provided' functions (add_mod, sub_mod and eval_poly) demote from usize to u32

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -218,9 +218,8 @@ pub trait Engine {
 
         Self::fwht(erasures, truncated_size);
 
-        for i in 0..GF_ORDER {
-            erasures[i] = (((erasures[i] as usize) * (log_walsh[i] as usize))
-                % (GF_MODULUS as usize)) as GfElement;
+        for (e, factor) in std::iter::zip(erasures.iter_mut(), log_walsh.iter()) {
+            *e = ((u32::from(*e) * u32::from(*factor)) % u32::from(GF_MODULUS)) as GfElement;
         }
 
         Self::fwht(erasures, GF_ORDER);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -93,14 +93,14 @@ pub type GfElement = u16;
 /// Some kind of addition.
 #[inline(always)]
 pub fn add_mod(x: GfElement, y: GfElement) -> GfElement {
-    let sum: usize = (x as usize) + (y as usize);
+    let sum = u32::from(x) + u32::from(y);
     (sum + (sum >> GF_BITS)) as GfElement
 }
 
 /// Some kind of subtraction.
 #[inline(always)]
 pub fn sub_mod(x: GfElement, y: GfElement) -> GfElement {
-    let dif: usize = (x as usize).wrapping_sub(y as usize);
+    let dif = u32::from(x).wrapping_sub(u32::from(y));
     dif.wrapping_add(dif >> GF_BITS) as GfElement
 }
 


### PR DESCRIPTION
..as u32 is enough