### PR TITLE
Avoid calloc for encoder

### DIFF
--- a/src/rate/decoder_work.rs
+++ b/src/rate/decoder_work.rs
@@ -176,7 +176,7 @@ impl DecoderWork {
             self.received.grow(max_received_pos);
         }
 
-        self.shards.resize(work_count, shard_bytes);
+        self.shards.zero_alloc(work_count, shard_bytes);
     }
 
     pub(crate) fn reset_received(&mut self) {

--- a/src/rate/encoder_work.rs
+++ b/src/rate/encoder_work.rs
@@ -62,9 +62,7 @@ impl EncoderWork {
                 got: original_shard.len(),
             })
         } else {
-            self.shards[self.original_received_count]
-                .as_flattened_mut()
-                .copy_from_slice(original_shard);
+            self.shards.push(original_shard);
             self.original_received_count += 1;
             Ok(())
         }
@@ -77,6 +75,7 @@ impl EncoderWork {
                 original_received_count: self.original_received_count,
             })
         } else {
+            self.shards.clear_recovery();
             Ok((
                 self.shards.as_ref_mut(),
                 self.original_count,


### PR DESCRIPTION
The idea is to avoid writing a ton of 0's, as we'll overwrite most of them with original shards.

For decoder work we still allocate a ton of 0's, as we might not get the shards in order.

I'm yet to see examples where this makes a noticeable difference. 