### PR TITLE
Prepare for `no_std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: "1.80"
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.81"
 
-    - name: Build
-      run: cargo build --verbose
+      - name: Build
+        run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose -- --include-ignored
+      - name: Run tests
+        run: cargo test --verbose -- --include-ignored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,13 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ include = [
 [dependencies]
 fixedbitset = "0.4.0"
 
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+cpufeatures = "0.2.17"
+
 [build-dependencies]
 readme-rustdocifier = "0.1.0"
 

--- a/src/engine/engine_avx2.rs
+++ b/src/engine/engine_avx2.rs
@@ -1,9 +1,9 @@
-use std::iter::zip;
+use core::iter::zip;
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
@@ -111,28 +111,28 @@ impl From<&Multiply128lutT> for LutAvx2 {
         unsafe {
             Self {
                 t0_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>(),
                 )),
                 t1_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>(),
                 )),
                 t2_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>(),
                 )),
                 t3_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>(),
                 )),
                 t0_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>(),
                 )),
                 t1_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>(),
                 )),
                 t2_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>(),
                 )),
                 t3_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>(),
                 )),
             }
         }

--- a/src/engine/engine_default.rs
+++ b/src/engine/engine_default.rs
@@ -26,18 +26,21 @@ impl DefaultEngine {
     pub fn new() -> Self {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
                 return Self(Box::new(Avx2::new()));
             }
 
-            if is_x86_feature_detected!("ssse3") {
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
                 return Self(Box::new(Ssse3::new()));
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
                 return Self(Box::new(Neon::new()));
             }
         }
@@ -88,18 +91,21 @@ impl Engine for DefaultEngine {
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
                 return Avx2::eval_poly(erasures, truncated_size);
             }
 
-            if is_x86_feature_detected!("ssse3") {
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
                 return Ssse3::eval_poly(erasures, truncated_size);
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
                 return Neon::eval_poly(erasures, truncated_size);
             }
         }

--- a/src/engine/engine_naive.rs
+++ b/src/engine/engine_naive.rs
@@ -134,7 +134,7 @@ impl Naive {
     fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
         debug_assert_eq!(x.len(), y.len());
 
-        for (x_chunk, y_chunk) in std::iter::zip(x.iter_mut(), y.iter()) {
+        for (x_chunk, y_chunk) in core::iter::zip(x.iter_mut(), y.iter()) {
             for i in 0..32 {
                 let lo = GfElement::from(y_chunk[i]);
                 let hi = GfElement::from(y_chunk[i + 32]);

--- a/src/engine/engine_neon.rs
+++ b/src/engine/engine_neon.rs
@@ -2,8 +2,8 @@ use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
     utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
 };
-use std::arch::aarch64::*;
-use std::iter::zip;
+use core::arch::aarch64::*;
+use core::iter::zip;
 
 // ======================================================================
 // Neon - PUBLIC
@@ -123,15 +123,15 @@ impl Neon {
         let mut prod_hi: uint8x16_t;
 
         unsafe {
-            let t0_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
-            let t1_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
-            let t2_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<u8>());
-            let t3_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<u8>());
+            let t0_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
+            let t1_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
+            let t2_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<u8>());
+            let t3_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<u8>());
 
-            let t0_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<u8>());
-            let t1_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<u8>());
-            let t2_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<u8>());
-            let t3_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<u8>());
+            let t0_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<u8>());
+            let t1_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<u8>());
+            let t2_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<u8>());
+            let t3_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<u8>());
 
             let clr_mask = vdupq_n_u8(0x0f);
 

--- a/src/engine/engine_nosimd.rs
+++ b/src/engine/engine_nosimd.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use core::iter::zip;
 
 use crate::engine::{
     tables::{self, Mul16, Skew},

--- a/src/engine/engine_ssse3.rs
+++ b/src/engine/engine_ssse3.rs
@@ -1,9 +1,9 @@
-use std::iter::zip;
+use core::iter::zip;
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
@@ -122,15 +122,15 @@ impl Ssse3 {
         let mut prod_hi: __m128i;
 
         unsafe {
-            let t0_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
-            let t1_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
-            let t2_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>());
-            let t3_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>());
+            let t0_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
+            let t1_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
+            let t2_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>());
+            let t3_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>());
 
-            let t0_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>());
-            let t1_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>());
-            let t2_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>());
-            let t3_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>());
+            let t0_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>());
+            let t1_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>());
+            let t2_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>());
+            let t3_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>());
 
             let clr_mask = _mm_set1_epi8(0x0f);
 

--- a/src/engine/shards.rs
+++ b/src/engine/shards.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, Index, IndexMut, Range, RangeBounds};
+use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
 
 // ======================================================================
 // Shards - CRATE

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -3,7 +3,7 @@
 //! [`Engine`]: crate::engine::Engine
 
 use crate::engine::{fwht, tables, Engine, GfElement, ShardsRefMut, GF_BITS, GF_ORDER};
-use std::iter::zip;
+use core::iter::zip;
 
 // ======================================================================
 // FUNCTIONS - PUBLIC
@@ -22,7 +22,7 @@ pub fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
 
     fwht::fwht(erasures, truncated_size);
 
-    for (e, factor) in std::iter::zip(erasures.iter_mut(), log_walsh.iter()) {
+    for (e, factor) in zip(erasures.iter_mut(), log_walsh.iter()) {
         let product = u32::from(*e) * u32::from(*factor);
         *e = add_mod(product as GfElement, (product >> GF_BITS) as GfElement);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
     clippy::wildcard_imports
 )]
 
-use std::{collections::HashMap, fmt};
+use core::fmt;
+use std::collections::HashMap;
 
 pub use crate::{
     decoder_result::{DecoderResult, RestoredOriginal},
@@ -227,7 +228,7 @@ impl fmt::Display for Error {
 // ======================================================================
 // Error - IMPL ERROR
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 // ======================================================================
 // FUNCTIONS - PUBLIC

--- a/src/rate/decoder_work.rs
+++ b/src/rate/decoder_work.rs
@@ -166,7 +166,7 @@ impl DecoderWork {
         self.original_received_count = 0;
         self.recovery_received_count = 0;
 
-        let max_received_pos = std::cmp::max(
+        let max_received_pos = core::cmp::max(
             original_base_pos + original_count,
             recovery_base_pos + recovery_count,
         );

--- a/src/rate/rate_default.rs
+++ b/src/rate/rate_default.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, marker::PhantomData};
+use core::{cmp::Ordering, marker::PhantomData};
 
 use crate::{
     engine::{Engine, GF_ORDER},
@@ -23,8 +23,8 @@ fn use_high_rate(original_count: usize, recovery_count: usize) -> Result<bool, E
     let original_count_pow2 = original_count.next_power_of_two();
     let recovery_count_pow2 = recovery_count.next_power_of_two();
 
-    let smaller_pow2 = std::cmp::min(original_count_pow2, recovery_count_pow2);
-    let larger = std::cmp::max(original_count, recovery_count);
+    let smaller_pow2 = core::cmp::min(original_count_pow2, recovery_count_pow2);
+    let larger = core::cmp::max(original_count, recovery_count);
 
     if original_count == 0 || recovery_count == 0 || smaller_pow2 + larger > GF_ORDER {
         return Err(Error::UnsupportedShardCount {
@@ -166,7 +166,7 @@ impl<E: Engine> RateEncoder<E> for DefaultRateEncoder<E> {
     ) -> Result<(), Error> {
         let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
 
-        self.0 = match std::mem::take(&mut self.0) {
+        self.0 = match core::mem::take(&mut self.0) {
             InnerEncoder::High(mut high) => {
                 if new_rate_is_high {
                     high.reset(original_count, recovery_count, shard_bytes)?;
@@ -310,7 +310,7 @@ impl<E: Engine> RateDecoder<E> for DefaultRateDecoder<E> {
     ) -> Result<(), Error> {
         let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
 
-        self.0 = match std::mem::take(&mut self.0) {
+        self.0 = match core::mem::take(&mut self.0) {
             InnerDecoder::High(mut high) => {
                 if new_rate_is_high {
                     high.reset(original_count, recovery_count, shard_bytes)?;
@@ -371,7 +371,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/rate/rate_high.rs
+++ b/src/rate/rate_high.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     engine::{self, Engine, GF_MODULUS, GF_ORDER},
@@ -48,7 +48,7 @@ impl<E: Engine> RateEncoder<E> for HighRateEncoder<E> {
 
         // FIRST CHUNK
 
-        let first_count = std::cmp::min(original_count, chunk_size);
+        let first_count = core::cmp::min(original_count, chunk_size);
 
         work.zero(first_count..chunk_size);
         engine::ifft_skew_end(engine, &mut work, 0, chunk_size, first_count);
@@ -352,7 +352,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/rate/rate_low.rs
+++ b/src/rate/rate_low.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     engine::{self, Engine, GF_MODULUS, GF_ORDER},
@@ -352,7 +352,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ops::Range};
+use core::ops::Range;
+use std::collections::HashMap;
 
 use fixedbitset::FixedBitSet;
 use rand::{Rng, SeedableRng};


### PR DESCRIPTION
I'd like to use this library in `no_std` environment (with an allocator) and this is the first set of changes that is a step towards that.

This doesn't achieve `no_std` yet because of `HashMap` and `LazyLock` usage, both of which will be breaking API changes, so I want to discuss them first.

For `HashMap` I think it should be replaced with `Vec`, which will be more efficient and compatible with `no_std`.

For `LazyLock` my preference would be to not use global statics and instead require a handle in various operations, such that the caller can initialize things once and call multiple times as needed. But the simplest approach for now would be to use https://docs.rs/once_cell/latest/once_cell/race/struct.OnceBox.html in `no_std` and continue using `LazyLock` otherwise.