### PR TITLE
`no_std` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.81"
+          toolchain: "1.82"
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose -- --include-ignored
+
+      - name: Run tests (no_std)
+        run: cargo test --verbose --no-default-features -- --include-ignored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: "1.80"
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.81"
 
-    - name: Build
-      run: cargo build --verbose
+      - name: Build
+        run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose -- --include-ignored
+      - name: Run tests
+        run: cargo test --verbose -- --include-ignored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,13 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 
 ## 3.1.0 - UNRELEASED
 - `no_std` support when new `std` feature is disabled (`std` feature is enabled by default).
+- Require Rust 1.81.0 or newer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,6 @@
 
 ## 3.0.1 - 2024-11-23
 - AVX2: Up to 20% higher throughput in encoding and up to 10% faster decoding.
+
+## 3.1.0 - UNRELEASED
+- `no_std` support when new `std` feature is disabled (`std` feature is enabled by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,4 +36,4 @@
 
 ## 3.1.0 - UNRELEASED
 - `no_std` support when new `std` feature is disabled (`std` feature is enabled by default).
-- Require Rust 1.81.0 or newer
+- Require Rust 1.82.0 or newer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/AndersTrier/reed-solomon-simd"
 keywords = ["erasure", "reed-solomon", "Leopard-RS"]
 categories = ["algorithms", "encoding"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.81"
 
 include = [
     "/benches",
@@ -19,7 +19,7 @@ include = [
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-once_cell = { version = "1.21.3", default-features = false, features = ["race"] }
+once_cell = { version = "1.21.3", default-features = false, features = ["alloc", "race"] }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 cpufeatures = "0.2.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "reed-solomon-simd"
-version = "3.0.1"
+version = "3.1.0"
 license = "MIT AND BSD-3-Clause"
 description = "Reed-Solomon coding with O(n log n) complexity. Leverages SIMD instructions on x86(-64) and AArch64."
 repository = "https://github.com/AndersTrier/reed-solomon-simd"
-keywords = [ "erasure", "reed-solomon", "Leopard-RS" ]
-categories = [ "algorithms", "encoding" ]
+keywords = ["erasure", "reed-solomon", "Leopard-RS"]
+categories = ["algorithms", "encoding"]
 edition = "2021"
 rust-version = "1.80"
 
@@ -18,7 +18,8 @@ include = [
 ]
 
 [dependencies]
-fixedbitset = "0.4.0"
+fixedbitset = { version = "0.4.0", default-features = false }
+once_cell = { version = "1.21.3", default-features = false, features = ["race"] }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 cpufeatures = "0.2.17"
@@ -27,7 +28,7 @@ cpufeatures = "0.2.17"
 readme-rustdocifier = "0.1.0"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = [ "html_reports" ] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 hex = "0.4.3"
 rand = "0.8.4"
 rand_chacha = "0.3.1"
@@ -35,9 +36,13 @@ sha2 = "0.10.0"
 
 # These are only for `examples/quick-comparison.rs`.
 reed-solomon-16 = "0.1.0"
-reed-solomon-erasure = { version = "6.0.0", features = [ "simd-accel" ] }
+reed-solomon-erasure = { version = "6.0.0", features = ["simd-accel"] }
 reed-solomon-novelpoly = "2.0.0"
 leopard-codec = "0.1.0"
+
+[features]
+default = ["std"]
+std = ["fixedbitset/std"]
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/AndersTrier/reed-solomon-simd"
 keywords = ["erasure", "reed-solomon", "Leopard-RS"]
 categories = ["algorithms", "encoding"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.82"
 
 include = [
     "/benches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ include = [
 [dependencies]
 fixedbitset = "0.4.0"
 
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+cpufeatures = "0.2.17"
+
 [build-dependencies]
 readme-rustdocifier = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -203,25 +203,25 @@ is based on [Leopard-RS] by Christopher A. Taylor.
 [Leopard-RS]: https://github.com/catid/leopard
 [reed-solomon-simd]: https://github.com/AndersTrier/reed-solomon-simd
 
-[`Naive`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/struct.Naive.html
-[`NoSimd`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/struct.NoSimd.html
-[`Ssse3`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/struct.Ssse3.html
-[`Avx2`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/struct.Avx2.html
-[`Neon`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/struct.Neon.html
+[`Naive`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/struct.Naive.html
+[`NoSimd`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/struct.NoSimd.html
+[`Ssse3`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/struct.Ssse3.html
+[`Avx2`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/struct.Avx2.html
+[`Neon`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/struct.Neon.html
 
-[`ReedSolomonEncoder`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonEncoder.html
-[RSE::add_original_shard]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonEncoder.html#method.add_original_shard
-[RSE::encode]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonEncoder.html#method.encode
+[`ReedSolomonEncoder`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonEncoder.html
+[RSE::add_original_shard]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonEncoder.html#method.add_original_shard
+[RSE::encode]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonEncoder.html#method.encode
 
-[`ReedSolomonDecoder`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonDecoder.html
-[RSD::add_original_shard]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.add_original_shard
-[RSD::add_recovery_shard]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.add_recovery_shard
-[RSD::decode]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.decode
+[`ReedSolomonDecoder`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonDecoder.html
+[RSD::add_original_shard]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.add_original_shard
+[RSD::add_recovery_shard]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.add_recovery_shard
+[RSD::decode]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/struct.ReedSolomonDecoder.html#method.decode
 
-[`Engine`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/engine/trait.Engine.html
-[`Rate`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/rate/trait.Rate.html
+[`Engine`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/engine/trait.Engine.html
+[`Rate`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/rate/trait.Rate.html
 
-[mod:rate]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/rate/index.html
+[mod:rate]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/rate/index.html
 
-[`reed_solomon_simd::encode`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/fn.encode.html
-[`reed_solomon_simd::decode`]: https://docs.rs/reed-solomon-simd/3.0.1/reed_solomon_simd/fn.decode.html
+[`reed_solomon_simd::encode`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/fn.encode.html
+[`reed_solomon_simd::decode`]: https://docs.rs/reed-solomon-simd/3.1.0/reed_solomon_simd/fn.decode.html

--- a/examples/quick-comparison.rs
+++ b/examples/quick-comparison.rs
@@ -47,8 +47,7 @@ fn test_reed_solomon_simd(count: usize) {
     let start = Instant::now();
 
     // This table is only used in decoding.
-    let log_walsh = &reed_solomon_simd::engine::tables::LOG_WALSH;
-    std::sync::LazyLock::force(log_walsh);
+    reed_solomon_simd::engine::tables::get_log_walsh();
 
     // This initializes the remaining needed tables.
     reed_solomon_simd::engine::DefaultEngine::new();

--- a/src/decoder_result.rs
+++ b/src/decoder_result.rs
@@ -103,6 +103,9 @@ mod tests {
     use super::*;
     use crate::{test_util, ReedSolomonDecoder, ReedSolomonEncoder};
 
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     fn simple_roundtrip(shard_size: usize) {
         let original = test_util::generate_original(3, shard_size, 0);
 

--- a/src/encoder_result.rs
+++ b/src/encoder_result.rs
@@ -102,6 +102,9 @@ mod tests {
     use super::*;
     use crate::{test_util, ReedSolomonEncoder};
 
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     #[test]
     // EncoderResult::recovery
     // EncoderResult::recovery_iter

--- a/src/engine/engine_avx2.rs
+++ b/src/engine/engine_avx2.rs
@@ -34,8 +34,8 @@ impl Avx2 {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let mul128 = &*tables::MUL128;
-        let skew = &*tables::SKEW;
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
 
         Self { mul128, skew }
     }

--- a/src/engine/engine_avx2.rs
+++ b/src/engine/engine_avx2.rs
@@ -1,9 +1,9 @@
-use std::iter::zip;
+use core::iter::zip;
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
@@ -111,28 +111,28 @@ impl From<&Multiply128lutT> for LutAvx2 {
         unsafe {
             Self {
                 t0_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>(),
                 )),
                 t1_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>(),
                 )),
                 t2_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>(),
                 )),
                 t3_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>(),
                 )),
                 t0_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>(),
                 )),
                 t1_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>(),
                 )),
                 t2_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>(),
                 )),
                 t3_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
-                    std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>(),
+                    core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>(),
                 )),
             }
         }

--- a/src/engine/engine_default.rs
+++ b/src/engine/engine_default.rs
@@ -26,18 +26,21 @@ impl DefaultEngine {
     pub fn new() -> Self {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
                 return Self(Box::new(Avx2::new()));
             }
 
-            if is_x86_feature_detected!("ssse3") {
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
                 return Self(Box::new(Ssse3::new()));
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
                 return Self(Box::new(Neon::new()));
             }
         }
@@ -88,18 +91,21 @@ impl Engine for DefaultEngine {
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
                 return Avx2::eval_poly(erasures, truncated_size);
             }
 
-            if is_x86_feature_detected!("ssse3") {
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
                 return Ssse3::eval_poly(erasures, truncated_size);
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
                 return Neon::eval_poly(erasures, truncated_size);
             }
         }

--- a/src/engine/engine_default.rs
+++ b/src/engine/engine_default.rs
@@ -1,4 +1,6 @@
 use crate::engine::{Engine, GfElement, NoSimd, ShardsRefMut, GF_ORDER};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::engine::{Avx2, Ssse3};

--- a/src/engine/engine_naive.rs
+++ b/src/engine/engine_naive.rs
@@ -28,8 +28,8 @@ impl Naive {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let exp_log = &*tables::EXP_LOG;
-        let skew = &*tables::SKEW;
+        let exp_log = &*tables::get_exp_log();
+        let skew = tables::get_skew();
 
         Self {
             exp: &exp_log.exp,

--- a/src/engine/engine_naive.rs
+++ b/src/engine/engine_naive.rs
@@ -28,7 +28,7 @@ impl Naive {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let exp_log = &*tables::get_exp_log();
+        let exp_log = tables::get_exp_log();
         let skew = tables::get_skew();
 
         Self {

--- a/src/engine/engine_naive.rs
+++ b/src/engine/engine_naive.rs
@@ -134,7 +134,7 @@ impl Naive {
     fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
         debug_assert_eq!(x.len(), y.len());
 
-        for (x_chunk, y_chunk) in std::iter::zip(x.iter_mut(), y.iter()) {
+        for (x_chunk, y_chunk) in core::iter::zip(x.iter_mut(), y.iter()) {
             for i in 0..32 {
                 let lo = GfElement::from(y_chunk[i]);
                 let hi = GfElement::from(y_chunk[i + 32]);

--- a/src/engine/engine_neon.rs
+++ b/src/engine/engine_neon.rs
@@ -2,8 +2,8 @@ use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
     utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
 };
-use std::arch::aarch64::*;
-use std::iter::zip;
+use core::arch::aarch64::*;
+use core::iter::zip;
 
 // ======================================================================
 // Neon - PUBLIC
@@ -123,15 +123,15 @@ impl Neon {
         let mut prod_hi: uint8x16_t;
 
         unsafe {
-            let t0_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
-            let t1_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
-            let t2_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<u8>());
-            let t3_lo = vld1q_u8(std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<u8>());
+            let t0_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
+            let t1_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
+            let t2_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<u8>());
+            let t3_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<u8>());
 
-            let t0_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<u8>());
-            let t1_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<u8>());
-            let t2_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<u8>());
-            let t3_hi = vld1q_u8(std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<u8>());
+            let t0_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<u8>());
+            let t1_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<u8>());
+            let t2_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<u8>());
+            let t3_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<u8>());
 
             let clr_mask = vdupq_n_u8(0x0f);
 

--- a/src/engine/engine_neon.rs
+++ b/src/engine/engine_neon.rs
@@ -29,8 +29,8 @@ impl Neon {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let mul128 = &*tables::MUL128;
-        let skew = &*tables::SKEW;
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
 
         Self { mul128, skew }
     }

--- a/src/engine/engine_nosimd.rs
+++ b/src/engine/engine_nosimd.rs
@@ -26,8 +26,8 @@ impl NoSimd {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let mul16 = &*tables::MUL16;
-        let skew = &*tables::SKEW;
+        let mul16 = tables::get_mul16();
+        let skew = tables::get_skew();
 
         Self { mul16, skew }
     }

--- a/src/engine/engine_nosimd.rs
+++ b/src/engine/engine_nosimd.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use core::iter::zip;
 
 use crate::engine::{
     tables::{self, Mul16, Skew},

--- a/src/engine/engine_nosimd.rs
+++ b/src/engine/engine_nosimd.rs
@@ -321,6 +321,8 @@ impl NoSimd {
 mod tests {
     use crate::engine::{Engine, Naive, NoSimd};
 
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 

--- a/src/engine/engine_ssse3.rs
+++ b/src/engine/engine_ssse3.rs
@@ -1,9 +1,9 @@
-use std::iter::zip;
+use core::iter::zip;
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 use crate::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
@@ -122,15 +122,15 @@ impl Ssse3 {
         let mut prod_hi: __m128i;
 
         unsafe {
-            let t0_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
-            let t1_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
-            let t2_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>());
-            let t3_lo = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>());
+            let t0_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
+            let t1_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
+            let t2_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>());
+            let t3_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>());
 
-            let t0_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>());
-            let t1_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>());
-            let t2_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>());
-            let t3_hi = _mm_loadu_si128(std::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>());
+            let t0_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>());
+            let t1_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>());
+            let t2_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>());
+            let t3_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>());
 
             let clr_mask = _mm_set1_epi8(0x0f);
 

--- a/src/engine/engine_ssse3.rs
+++ b/src/engine/engine_ssse3.rs
@@ -34,8 +34,8 @@ impl Ssse3 {
     ///
     /// [`LogWalsh`]: crate::engine::tables::LogWalsh
     pub fn new() -> Self {
-        let mul128 = &*tables::MUL128;
-        let skew = &*tables::SKEW;
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
 
         Self { mul128, skew }
     }

--- a/src/engine/fwht.rs
+++ b/src/engine/fwht.rs
@@ -60,6 +60,8 @@ fn fwht_4(data: &mut [GfElement; GF_ORDER], offset: u16, dist: u16) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 

--- a/src/engine/shards.rs
+++ b/src/engine/shards.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, Index, IndexMut, Range, RangeBounds};
+use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
 
 // ======================================================================
 // Shards - CRATE

--- a/src/engine/shards.rs
+++ b/src/engine/shards.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
 
 // ======================================================================

--- a/src/engine/tables.rs
+++ b/src/engine/tables.rs
@@ -88,19 +88,35 @@ pub struct ExpLog {
 // STATIC - PUBLIC
 
 /// Lazily initialized exponentiation and logarithm tables.
-pub static EXP_LOG: LazyLock<ExpLog> = LazyLock::new(initialize_exp_log);
+pub fn get_exp_log() -> &'static ExpLog {
+    static EXP_LOG: LazyLock<ExpLog> = LazyLock::new(initialize_exp_log);
+
+    &EXP_LOG
+}
 
 /// Lazily initialized logarithmic Walsh transform table.
-pub static LOG_WALSH: LazyLock<Box<LogWalsh>> = LazyLock::new(initialize_log_walsh);
+pub fn get_log_walsh() -> &'static LogWalsh {
+    static LOG_WALSH: LazyLock<Box<LogWalsh>> = LazyLock::new(initialize_log_walsh);
+    &LOG_WALSH
+}
 
 /// Lazily initialized multiplication table for the `NoSimd` engine.
-pub static MUL16: LazyLock<Box<Mul16>> = LazyLock::new(initialize_mul16);
+pub fn get_mul16() -> &'static Mul16 {
+    static MUL16: LazyLock<Box<Mul16>> = LazyLock::new(initialize_mul16);
+    &MUL16
+}
 
 /// Lazily initialized multiplication table for SIMD engines.
-pub static MUL128: LazyLock<Box<Mul128>> = LazyLock::new(initialize_mul128);
+pub fn get_mul128() -> &'static Mul128 {
+    static MUL128: LazyLock<Box<Mul128>> = LazyLock::new(initialize_mul128);
+    &MUL128
+}
 
 /// Lazily initialized skew table used in FFT and IFFT operations.
-pub static SKEW: LazyLock<Box<Skew>> = LazyLock::new(initialize_skew);
+pub fn get_skew() -> &'static Skew {
+    static SKEW: LazyLock<Box<Skew>> = LazyLock::new(initialize_skew);
+    &SKEW
+}
 
 // ======================================================================
 // FUNCTIONS - PUBLIC - math
@@ -159,11 +175,11 @@ fn initialize_exp_log() -> ExpLog {
 }
 
 fn initialize_log_walsh() -> Box<LogWalsh> {
-    let log = *EXP_LOG.log;
+    let log = get_exp_log().log.as_slice();
 
     let mut log_walsh: Box<LogWalsh> = Box::new([0; GF_ORDER]);
 
-    log_walsh.copy_from_slice(log.as_ref());
+    log_walsh.copy_from_slice(log);
     log_walsh[0] = 0;
     fwht::fwht(log_walsh.as_mut(), GF_ORDER);
 
@@ -171,8 +187,8 @@ fn initialize_log_walsh() -> Box<LogWalsh> {
 }
 
 fn initialize_mul16() -> Box<Mul16> {
-    let exp = &*EXP_LOG.exp;
-    let log = &*EXP_LOG.log;
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
     let mut mul16 = vec![[[0; 16]; 4]; GF_ORDER];
 
     for log_m in 0..=GF_MODULUS {
@@ -191,8 +207,8 @@ fn initialize_mul16() -> Box<Mul16> {
 fn initialize_mul128() -> Box<Mul128> {
     // Based on:
     // https://github.com/catid/leopard/blob/22ddc7804998d31c8f1a2617ee720e063b1fa6cd/LeopardFF16.cpp#L375
-    let exp = &*EXP_LOG.exp;
-    let log = &*EXP_LOG.log;
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
 
     let mut mul128 = vec![
         Multiply128lutT {
@@ -221,8 +237,8 @@ fn initialize_mul128() -> Box<Mul128> {
 
 #[allow(clippy::needless_range_loop)]
 fn initialize_skew() -> Box<Skew> {
-    let exp = &*EXP_LOG.exp;
-    let log = &*EXP_LOG.log;
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
 
     let mut skew = Box::new([0; GF_MODULUS as usize]);
 

--- a/src/engine/tables.rs
+++ b/src/engine/tables.rs
@@ -19,6 +19,13 @@
 //! [`Engine`]: crate::engine
 //!
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use once_cell::race::OnceBox;
+#[cfg(feature = "std")]
 use std::sync::LazyLock;
 
 use crate::engine::{
@@ -89,33 +96,72 @@ pub struct ExpLog {
 
 /// Lazily initialized exponentiation and logarithm tables.
 pub fn get_exp_log() -> &'static ExpLog {
-    static EXP_LOG: LazyLock<ExpLog> = LazyLock::new(initialize_exp_log);
-
-    &EXP_LOG
+    #[cfg(feature = "std")]
+    {
+        static EXP_LOG: LazyLock<ExpLog> = LazyLock::new(initialize_exp_log);
+        &EXP_LOG
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static EXP_LOG: OnceBox<ExpLog> = OnceBox::new();
+        EXP_LOG.get_or_init(|| Box::new(initialize_exp_log()))
+    }
 }
 
 /// Lazily initialized logarithmic Walsh transform table.
 pub fn get_log_walsh() -> &'static LogWalsh {
-    static LOG_WALSH: LazyLock<Box<LogWalsh>> = LazyLock::new(initialize_log_walsh);
-    &LOG_WALSH
+    #[cfg(feature = "std")]
+    {
+        static LOG_WALSH: LazyLock<Box<LogWalsh>> = LazyLock::new(initialize_log_walsh);
+        &LOG_WALSH
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static LOG_WALSH: OnceBox<LogWalsh> = OnceBox::new();
+        LOG_WALSH.get_or_init(initialize_log_walsh)
+    }
 }
 
 /// Lazily initialized multiplication table for the `NoSimd` engine.
 pub fn get_mul16() -> &'static Mul16 {
-    static MUL16: LazyLock<Box<Mul16>> = LazyLock::new(initialize_mul16);
-    &MUL16
+    #[cfg(feature = "std")]
+    {
+        static MUL16: LazyLock<Box<Mul16>> = LazyLock::new(initialize_mul16);
+        &MUL16
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static MUL16: OnceBox<Mul16> = OnceBox::new();
+        MUL16.get_or_init(initialize_mul16)
+    }
 }
 
 /// Lazily initialized multiplication table for SIMD engines.
 pub fn get_mul128() -> &'static Mul128 {
-    static MUL128: LazyLock<Box<Mul128>> = LazyLock::new(initialize_mul128);
-    &MUL128
+    #[cfg(feature = "std")]
+    {
+        static MUL128: LazyLock<Box<Mul128>> = LazyLock::new(initialize_mul128);
+        &MUL128
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static MUL128: OnceBox<Mul128> = OnceBox::new();
+        MUL128.get_or_init(initialize_mul128)
+    }
 }
 
 /// Lazily initialized skew table used in FFT and IFFT operations.
 pub fn get_skew() -> &'static Skew {
-    static SKEW: LazyLock<Box<Skew>> = LazyLock::new(initialize_skew);
-    &SKEW
+    #[cfg(feature = "std")]
+    {
+        static SKEW: LazyLock<Box<Skew>> = LazyLock::new(initialize_skew);
+        &SKEW
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static SKEW: OnceBox<Skew> = OnceBox::new();
+        SKEW.get_or_init(initialize_skew)
+    }
 }
 
 // ======================================================================

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -3,7 +3,7 @@
 //! [`Engine`]: crate::engine::Engine
 
 use crate::engine::{fwht, tables, Engine, GfElement, ShardsRefMut, GF_BITS, GF_ORDER};
-use std::iter::zip;
+use core::iter::zip;
 
 // ======================================================================
 // FUNCTIONS - PUBLIC
@@ -22,7 +22,7 @@ pub fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
 
     fwht::fwht(erasures, truncated_size);
 
-    for (e, factor) in std::iter::zip(erasures.iter_mut(), log_walsh.iter()) {
+    for (e, factor) in zip(erasures.iter_mut(), log_walsh.iter()) {
         let product = u32::from(*e) * u32::from(*factor);
         *e = add_mod(product as GfElement, (product >> GF_BITS) as GfElement);
     }

--- a/src/engine/utils.rs
+++ b/src/engine/utils.rs
@@ -18,7 +18,7 @@ use core::iter::zip;
 /// [`Avx2`]: crate::engine::Avx2
 #[inline(always)]
 pub fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
-    let log_walsh = &*tables::LOG_WALSH;
+    let log_walsh = tables::get_log_walsh();
 
     fwht::fwht(erasures, truncated_size);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
     clippy::wildcard_imports
 )]
 
-use std::{collections::HashMap, fmt};
+use core::fmt;
+use std::collections::HashMap;
 
 pub use crate::{
     decoder_result::{DecoderResult, RestoredOriginal},
@@ -227,7 +228,7 @@ impl fmt::Display for Error {
 // ======================================================================
 // Error - IMPL ERROR
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 // ======================================================================
 // FUNCTIONS - PUBLIC

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,14 @@
     clippy::large_stack_arrays,
     clippy::wildcard_imports
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::fmt;
-use std::collections::HashMap;
 
 pub use crate::{
     decoder_result::{DecoderResult, RestoredOriginal},
@@ -293,7 +298,7 @@ pub fn decode<O, R, OT, RT>(
     recovery_count: usize,
     original: O,
     recovery: R,
-) -> Result<HashMap<usize, Vec<u8>>, Error>
+) -> Result<BTreeMap<usize, Vec<u8>>, Error>
 where
     O: IntoIterator<Item = (usize, OT)>,
     R: IntoIterator<Item = (usize, RT)>,
@@ -318,7 +323,7 @@ where
         let original_received_count = original.count();
         if original_received_count == original_count {
             // Nothing to do, original data is complete.
-            return Ok(HashMap::new());
+            return Ok(BTreeMap::new());
         }
 
         return Err(Error::NotEnoughShards {
@@ -339,7 +344,7 @@ where
         decoder.add_recovery_shard(index, recovery)?;
     }
 
-    let mut result = HashMap::new();
+    let mut result = BTreeMap::new();
     for (index, original) in decoder.decode()?.restored_original_iter() {
         result.insert(index, original.to_vec());
     }

--- a/src/rate/decoder_work.rs
+++ b/src/rate/decoder_work.rs
@@ -166,7 +166,7 @@ impl DecoderWork {
         self.original_received_count = 0;
         self.recovery_received_count = 0;
 
-        let max_received_pos = std::cmp::max(
+        let max_received_pos = core::cmp::max(
             original_base_pos + original_count,
             recovery_base_pos + recovery_count,
         );

--- a/src/rate/rate_default.rs
+++ b/src/rate/rate_default.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, marker::PhantomData};
+use core::{cmp::Ordering, marker::PhantomData};
 
 use crate::{
     engine::{Engine, GF_ORDER},
@@ -23,8 +23,8 @@ fn use_high_rate(original_count: usize, recovery_count: usize) -> Result<bool, E
     let original_count_pow2 = original_count.next_power_of_two();
     let recovery_count_pow2 = recovery_count.next_power_of_two();
 
-    let smaller_pow2 = std::cmp::min(original_count_pow2, recovery_count_pow2);
-    let larger = std::cmp::max(original_count, recovery_count);
+    let smaller_pow2 = core::cmp::min(original_count_pow2, recovery_count_pow2);
+    let larger = core::cmp::max(original_count, recovery_count);
 
     if original_count == 0 || recovery_count == 0 || smaller_pow2 + larger > GF_ORDER {
         return Err(Error::UnsupportedShardCount {
@@ -166,7 +166,7 @@ impl<E: Engine> RateEncoder<E> for DefaultRateEncoder<E> {
     ) -> Result<(), Error> {
         let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
 
-        self.0 = match std::mem::take(&mut self.0) {
+        self.0 = match core::mem::take(&mut self.0) {
             InnerEncoder::High(mut high) => {
                 if new_rate_is_high {
                     high.reset(original_count, recovery_count, shard_bytes)?;
@@ -310,7 +310,7 @@ impl<E: Engine> RateDecoder<E> for DefaultRateDecoder<E> {
     ) -> Result<(), Error> {
         let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
 
-        self.0 = match std::mem::take(&mut self.0) {
+        self.0 = match core::mem::take(&mut self.0) {
             InnerDecoder::High(mut high) => {
                 if new_rate_is_high {
                     high.reset(original_count, recovery_count, shard_bytes)?;
@@ -371,7 +371,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/rate/rate_high.rs
+++ b/src/rate/rate_high.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     engine::{self, Engine, GF_MODULUS, GF_ORDER},
@@ -48,7 +48,7 @@ impl<E: Engine> RateEncoder<E> for HighRateEncoder<E> {
 
         // FIRST CHUNK
 
-        let first_count = std::cmp::min(original_count, chunk_size);
+        let first_count = core::cmp::min(original_count, chunk_size);
 
         work.zero(first_count..chunk_size);
         engine::ifft_skew_end(engine, &mut work, 0, chunk_size, first_count);
@@ -352,7 +352,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/rate/rate_low.rs
+++ b/src/rate/rate_low.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     engine::{self, Engine, GF_MODULUS, GF_ORDER},
@@ -352,7 +352,7 @@ mod tests {
                 1024,
                 recovery_hash,
                 &[*recovery_count..*original_count],
-                &[0..std::cmp::min(*original_count, *recovery_count)],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
                 *seed,
             );
         }

--- a/src/reed_solomon.rs
+++ b/src/reed_solomon.rs
@@ -187,7 +187,9 @@ impl ReedSolomonDecoder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use alloc::collections::BTreeMap;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
 
     use fixedbitset::FixedBitSet;
 
@@ -229,7 +231,7 @@ mod tests {
         }
 
         let result = decoder.decode().unwrap();
-        let restored: HashMap<_, _> = result.restored_original_iter().collect();
+        let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
 
         for i in 0..original_count {
             if !original_received[i] {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ops::Range};
+use core::ops::Range;
+use std::collections::HashMap;
 
 use fixedbitset::FixedBitSet;
 use rand::{Rng, SeedableRng};

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,9 @@
+use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::ops::Range;
-use std::collections::HashMap;
 
 use fixedbitset::FixedBitSet;
 use rand::{Rng, SeedableRng};
@@ -56,12 +60,15 @@ where
     let got = sha.finalize();
 
     if &got[..] != hex::decode(expected).unwrap() {
-        print!("GOT     : ");
-        for x in got {
-            print!("{:02x}", x);
+        #[cfg(feature = "std")]
+        {
+            print!("GOT     : ");
+            for x in got {
+                print!("{:02x}", x);
+            }
+            println!();
+            println!("EXPECTED: {}", expected);
         }
-        println!();
-        println!("EXPECTED: {}", expected);
         panic!("recovery shards hash doesn't match");
     }
 }
@@ -119,7 +126,7 @@ pub(crate) fn roundtrip<R: Rate<E>, E: Engine, T: IntOrRange>(
     }
 
     let result = decoder.decode().unwrap();
-    let restored: HashMap<_, _> = result.restored_original_iter().collect();
+    let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
 
     for i in 0..original_count {
         if !original_received[i] {


### PR DESCRIPTION
This is a trivial implementation of `no_std` support.

It still requires global allocator, but otherwise will work on platforms without full standard library.

I originally opened https://github.com/AndersTrier/reed-solomon-simd/pull/62, but it wasn't difficult to finish the implementation, hence this PR.

Each commit is focused on a specific change for easier review.